### PR TITLE
修正jieba分词highlight错误和索引时出现的startOffset must be non-negative错误

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ hs_err_pid*
 build/
 gradle/
 
+*.iml

--- a/README.md
+++ b/README.md
@@ -1,23 +1,21 @@
 # elasticsearch-jieba-plugin
-jieba analysis plugin for elasticsearch: ***5.4.0***, ***5.3.0***, ***5.2.2***, ***5.2.1***, ***5.2.0***, ***5.1.2***, ***5.1.1***
+jieba analysis plugin for elasticsearch: ***5.4.2***, ***5.4.0***,***5.3.0***, ***5.2.2***, ***5.2.1***, ***5.2.0***, ***5.1.2***, ***5.1.1***
 
+###因由及主要变更
+原版本中有两个严重bug： 
+- ES中的分词在做highlight的时候，文字出现重叠。
+- ES在打开offset模式进行索引时，会报错误
+```shell
+reason=startOffset must be non-negative, and endOffset must be >= startOffset, and offsets must not go backwards
+```
+由于这个错误在所有的分支中都存在，且每个分支的差别仅在于版本号配置，所以我删除了所有的分支tag。
 
-### 版本对应
+### 插件(by version)直接下载
+***In todo list.***
 
-| 分支      | tag        | elasticsearch版本 | Release Link                                                                                  |
-| ---       | ---        | ---               | ---                                                                                           |
-| 5.4.0     | tag v5.4.0 | v5.4.0            | Download: [v5.4.0](https://github.com/sing1ee/elasticsearch-jieba-plugin/releases/tag/v5.4.0) |
-| 5.3.0     | tag v5.3.0 | v5.3.0            | Download: [v5.3.0](https://github.com/sing1ee/elasticsearch-jieba-plugin/releases/tag/v5.3.0) |
-| 5.2.2     | tag v5.2.2 | v5.2.2            | Download: [v5.2.2](https://github.com/sing1ee/elasticsearch-jieba-plugin/releases/tag/v5.2.2) |
-| 5.2.1     | tag v5.2.1 | v5.2.1            | Download: [v5.2.1](https://github.com/sing1ee/elasticsearch-jieba-plugin/releases/tag/v5.2.1) |
-| 5.2       | tag v5.2.0 | v5.2.0            | Download: [v5.2.0](https://github.com/sing1ee/elasticsearch-jieba-plugin/releases/tag/v5.2.0) |
-| 5.1.2     | tag v5.1.2 | v5.1.2            | Download: [v5.1.2](https://github.com/sing1ee/elasticsearch-jieba-plugin/releases/tag/v5.1.2) |
-| 5.1.1     | tag v5.1.1 | v5.1.1            | Download: [v5.1.1](https://github.com/sing1ee/elasticsearch-jieba-plugin/releases/tag/v5.1.1) |
-
-
-
-### more details
-- choose right version source code.
+### more detail
+- download the souce from master
+- change version and elasticsearch version  as your es version in file ***build.gradle*** and ***main/resouces/plugin-descriptor.properties***
 - run
 
 ```shell
@@ -26,7 +24,7 @@ gradle pz
 - copy the zip file to plugin directory
 
 ```shell
-cp build/distributions/elasticsearch-jieba-plugin-5.1.2.zip ${path.home}/plugins
+cp build/distributions/elasticsearch-jieba-plugin-5.3.0.zip ${path.home}/plugins
 ```
 - unzip and rm zip file
 
@@ -359,9 +357,9 @@ Query:
 migrate from [jieba-solr](https://github.com/sing1ee/jieba-solr)
 
 ### Roadmap
-I will add more analyzer support:
-- stanford chinese analyzer
-- fudan nlp analyzer
+I will add more for current branch support:
+- support dynamic version as parameter to build and package.
+- rebuild every downloadable package.
 - ...
 
 If you have some ideas, you should create an issue. Then, we will do it together.

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@
  */
 
 group 'org.elasticsearch'
-version = '5.1.2'
+version = '5.3.0'
 apply plugin: 'java'
 apply plugin: 'idea'
 
@@ -54,7 +54,7 @@ configurations {
 
 dependencies {
     compile 'com.huaban:jieba-analysis:1.0.2'
-    compile 'org.elasticsearch:elasticsearch:5.1.2'
+    compile 'org.elasticsearch:elasticsearch:5.3.0'
     compile 'org.apache.logging.log4j:log4j-api:2.7'
     compile 'org.apache.logging.log4j:log4j-core:2.7'
     testCompile 'junit:junit:4.12'

--- a/src/main/java/org/elasticsearch/index/analysis/JiebaAdapter.java
+++ b/src/main/java/org/elasticsearch/index/analysis/JiebaAdapter.java
@@ -2,6 +2,8 @@ package org.elasticsearch.index.analysis;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
@@ -18,6 +20,12 @@ public class JiebaAdapter implements Iterator<SegToken> {
   private Iterator<SegToken> tokens;
 
   private String raw = null;
+
+  //use a special comparator to order by startoffset asc and length(then endOffset) desc
+  //which can fix a bug cause highlight
+  private static final Comparator<SegToken> ComparatorSegToken = (s1, s2) -> {
+    return (s1.startOffset != s2.startOffset)?(s1.startOffset-s2.startOffset):(s2.endOffset-s1.endOffset);
+  };
 
   public JiebaAdapter(String segModeName) {
 
@@ -45,6 +53,8 @@ public class JiebaAdapter implements Iterator<SegToken> {
     }
 
     List<SegToken> list = jiebaTagger.process(raw, segMode);
+    //compare by startoffset asc and endoffset desc
+    Collections.sort(list,ComparatorSegToken);
     tokens = list.iterator();
   }
 

--- a/src/main/resources/plugin-descriptor.properties
+++ b/src/main/resources/plugin-descriptor.properties
@@ -34,7 +34,7 @@
 description=A jieba analysis of plugins for Elasticsearch
 #
 # 'version': plugin's version
-version=5.1.2
+version=5.3.0
 #
 # 'name': the plugin name
 name=analysis-jieba
@@ -68,7 +68,7 @@ java.version=1.8
 # elasticsearch release. This version is checked when the plugin
 # is loaded so Elasticsearch will refuse to start in the presence of
 # plugins with the incorrect elasticsearch.version.
-elasticsearch.version=5.1.2
+elasticsearch.version=5.3.0
 #
 ### deprecated elements for jvm plugins :
 #


### PR DESCRIPTION
1.fix bug when hightlight a jieba-index documents 
2.fix bug while inedexing documents raise exception about offset：
reason=startOffset must be non-negative, and endOffset must be >= startOffset, and offsets must not go backwards startOffset=74,endOffset=78,lastStartOffset=76 for field 'content'
3.modify readme to reflect actual case 
4.add .iml to gitignore